### PR TITLE
Separate supabase buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,14 @@ A web application for browsing, managing, and exporting high-quality image gener
    > **Important Note**: This project requires connecting to Supabase via the Lovable integration. 
    > Click the green Supabase button in the top-right of the Lovable interface to connect your project.
 
-4. Store your OpenAI API key in Supabase Edge Function Secrets
+4. Ensure the required storage buckets exist in your Supabase project. The
+   bucket `prompt-images` should already be present and remain private. Create
+   additional private buckets named `prompt-videos`, `prompt-audio` and
+   `prompt-files` for videos, audio clips and workflow files respectively. Also
+   ensure the `default-prompt-images` bucket exists for default images.
 
-5. Run the development server:
+5. Store your OpenAI API key in Supabase Edge Function Secrets
+6. Run the development server:
    ```
    npm run dev
    ```

--- a/src/components/ui/prompt-card/ImageWrapper.tsx
+++ b/src/components/ui/prompt-card/ImageWrapper.tsx
@@ -2,6 +2,7 @@ import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ImgHTMLAttributes, useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
+import { IMAGE_BUCKET } from "@/utils/buckets";
 import { AlertCircle } from "lucide-react";
 
 export function ImageWrapper({
@@ -63,7 +64,7 @@ export function ImageWrapper({
           
           const { data, error: supabaseError } = await supabase
             .storage
-            .from('prompt-images')
+            .from(IMAGE_BUCKET)
             .createSignedUrl(path, 300);
             
           if (supabaseError || !data?.signedUrl) {

--- a/src/utils/buckets.ts
+++ b/src/utils/buckets.ts
@@ -1,0 +1,5 @@
+export const IMAGE_BUCKET = 'prompt-images';
+export const VIDEO_BUCKET = 'prompt-videos';
+export const AUDIO_BUCKET = 'prompt-audio';
+export const FILE_BUCKET = 'prompt-files';
+export const DEFAULT_IMAGE_BUCKET = 'default-prompt-images';

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,11 +1,12 @@
 
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
+import { FILE_BUCKET } from "@/utils/buckets";
 
 export async function downloadWorkflowFile(filePath: string, fileName: string) {
   try {
     const { data, error } = await supabase.storage
-      .from('prompt-images')
+      .from(FILE_BUCKET)
       .download(filePath);
 
     if (error) {

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,10 +1,11 @@
 
 import { supabase } from "@/integrations/supabase/client";
+import { IMAGE_BUCKET, VIDEO_BUCKET, AUDIO_BUCKET, DEFAULT_IMAGE_BUCKET } from "@/utils/buckets";
 
 // The correct Supabase URL for this project
 const SUPABASE_URL = "https://fxkqgjakbyrxkmevkglv.supabase.co";
-const BUCKET = 'prompt-images';
-const DEFAULT_BUCKET = 'default-prompt-images';
+const BUCKET = IMAGE_BUCKET;
+const DEFAULT_BUCKET = DEFAULT_IMAGE_BUCKET;
 const DEFAULT_TEXT_PROMPT_IMAGE = 'textpromptdefaultimg.jpg';
 
 export async function getPromptImage(pathOrUrl: string | null | undefined, w = 400, q = 80): Promise<string> {
@@ -76,11 +77,13 @@ export async function getMediaUrl(pathOrUrl: string | null | undefined, mediaTyp
   console.log(`Getting ${mediaType} URL for path: ${cleanPath}`);
   
   try {
-    // For media files like video and audio, we want a direct URL without transformations
-    const bucket = BUCKET; // Always use the main bucket for media files
-    
+    // Choose the correct bucket based on the media type
+    let bucket = IMAGE_BUCKET;
+    if (mediaType === 'video') bucket = VIDEO_BUCKET;
+    if (mediaType === 'audio') bucket = AUDIO_BUCKET;
+
     console.log(`Using bucket: ${bucket} for ${mediaType} path: ${cleanPath}`);
-    
+
     // For images, we use the transformation API. For videos and audio, we get a direct URL
     if (mediaType === 'image') {
       return getPromptImage(pathOrUrl);

--- a/supabase/migrations/20240715000000_create_storage_buckets.sql
+++ b/supabase/migrations/20240715000000_create_storage_buckets.sql
@@ -1,0 +1,4 @@
+-- Create buckets for storing different prompt assets
+select storage.create_bucket('prompt-videos');
+select storage.create_bucket('prompt-audio');
+select storage.create_bucket('prompt-files');


### PR DESCRIPTION
## Summary
- centralize bucket names in `src/utils/buckets.ts`
- use bucket constants when uploading/downloading files
- choose buckets based on media type during uploads
- document the required buckets in the README
- add migration to create new storage buckets
- clarify README that `prompt-images` bucket already exists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*