### PR TITLE
Update Tap redirect handling

### DIFF
--- a/supabase/functions/create-tap-payment/index.ts
+++ b/supabase/functions/create-tap-payment/index.ts
@@ -174,12 +174,13 @@ serve(async (req: Request) => {
       source: {
         id: "src_all"
       },
-      // Use success URL for both post and redirect - Tap will add status parameters
+      // Post back to our server on success and redirect the user to the failure page.
+      // Tap appends the payment status to these URLs automatically.
       post: {
         url: successUrl
       },
       redirect: {
-        url: successUrl
+        url: failureUrl
       }
     };
 


### PR DESCRIPTION
## Summary
- set Tap redirect URL to failure page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843972a232c832099cee30f70f0bd1c