### PR TITLE
Validate payment status on subscription

### DIFF
--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -77,7 +77,22 @@ serve(async (req: Request) => {
     const paymentMethod = paymentData.paymentMethod || 'unknown';
     const paymentId = paymentData.paymentId || paymentData.payment_id || null;
 
-    console.log("Processing subscription for:", { userId, planId, paymentMethod, paymentId });
+    // Parse payment status from details
+    const rawStatus = paymentData?.details?.status;
+    const paymentStatus = typeof rawStatus === 'string' ? rawStatus.toUpperCase() : '';
+    console.log("Processing subscription for:", { userId, planId, paymentMethod, paymentId, paymentStatus });
+
+    // Only continue if payment was captured/paid
+    if (!['CAPTURED', 'PAID'].includes(paymentStatus)) {
+      console.error('Payment status not CAPTURED or PAID:', paymentStatus);
+      return new Response(
+        JSON.stringify({
+          error: 'Payment not completed',
+          status: paymentStatus || 'UNKNOWN'
+        }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 400 }
+      );
+    }
 
     // Get plan details
     console.log("Fetching plan details...");


### PR DESCRIPTION
## Summary
- ensure payment status is parsed from `paymentData.details.status`
- reject subscription creation unless status is `CAPTURED` or `PAID`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843972d1c8c8320b051961d898ea9bd