### PR TITLE
Handle session backup around PayPal redirects

### DIFF
--- a/src/components/payment/SimplePayPalButton.tsx
+++ b/src/components/payment/SimplePayPalButton.tsx
@@ -45,6 +45,22 @@ export function SimplePayPalButton({
         approvalUrl: data.approvalUrl
       });
 
+      // Backup current auth session tokens in case PayPal redirects clear them
+      try {
+        const { data: { session: currentSession } } = await supabase.auth.getSession();
+        if (currentSession?.access_token && currentSession?.refresh_token) {
+          localStorage.setItem(
+            'payPalSessionBackup',
+            JSON.stringify({
+              access_token: currentSession.access_token,
+              refresh_token: currentSession.refresh_token
+            })
+          );
+        }
+      } catch (backupError) {
+        console.error('Error backing up auth session for PayPal redirect:', backupError);
+      }
+
       // ENHANCED: Store comprehensive payment context in localStorage for callback recovery
       const paymentContext = {
         planId,

--- a/src/hooks/payment/usePaymentProcessing.ts
+++ b/src/hooks/payment/usePaymentProcessing.ts
@@ -180,6 +180,29 @@ export function usePaymentProcessing({
         return true;
       }
 
+      // Attempt restoration from localStorage backup created before PayPal redirection
+      const backupRaw = localStorage.getItem('payPalSessionBackup');
+      if (backupRaw) {
+        try {
+          const tokens = JSON.parse(backupRaw);
+          if (tokens?.access_token && tokens?.refresh_token) {
+            const { data: restored, error: restoreError } = await supabase.auth.setSession({
+              access_token: tokens.access_token,
+              refresh_token: tokens.refresh_token
+            });
+            if (!restoreError && restored.session?.user) {
+              console.log('[PaymentProcessing] Session restored from backup');
+              setCurrentUser(restored.session.user);
+              localStorage.removeItem('payPalSessionBackup');
+              return true;
+            }
+          }
+        } catch (parseError) {
+          console.error('[PaymentProcessing] Failed to restore session backup:', parseError);
+          localStorage.removeItem('payPalSessionBackup');
+        }
+      }
+
       // If we know the user ID from transaction, we can proceed without session
       if (transactionUserId) {
         console.log(`[PaymentProcessing] Proceeding with transaction user ID:`, transactionUserId);


### PR DESCRIPTION
## Summary
- back up Supabase auth session before leaving for PayPal
- restore session from the backup if callback lacks a session

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eea8bdfe48320b6ca0854dd7091b9