### PR TITLE
Add service role transaction lookup

### DIFF
--- a/supabase/functions/get-transaction-by-order/index.ts
+++ b/supabase/functions/get-transaction-by-order/index.ts
@@ -1,0 +1,68 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.50.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL") || "";
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    let body: any = {};
+    try {
+      body = await req.json();
+    } catch {}
+    const url = new URL(req.url);
+    const orderId = body.orderId || body.order_id || url.searchParams.get("orderId") || url.searchParams.get("order_id");
+
+    if (!orderId) {
+      return new Response(JSON.stringify({ error: "Missing orderId" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" }
+      });
+    }
+
+    const { data: transaction, error: txError } = await supabase
+      .from("transactions")
+      .select("*, user_subscriptions!left(*)")
+      .eq("paypal_order_id", orderId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (txError) {
+      return new Response(JSON.stringify({ error: txError.message }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" }
+      });
+    }
+
+    if (!transaction) {
+      return new Response(JSON.stringify({ transaction: null, subscription: null }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" }
+      });
+    }
+
+    const subscription = Array.isArray(transaction.user_subscriptions) && transaction.user_subscriptions.length > 0
+      ? transaction.user_subscriptions[0]
+      : null;
+
+    return new Response(
+      JSON.stringify({ transaction, subscription }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err?.message || "Server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add new `get-transaction-by-order` edge function
- fetch order details via this edge function when session data is missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eea8fa6dc83209847b81a63cb5421