### PR TITLE
Add API key troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ A web application for browsing, managing, and exporting high-quality image gener
    npm run dev
    ```
 
+### Troubleshooting
+
+Admins and prompters must ensure `OPENAI_API_KEY` is saved in your Supabase Edge
+Function secrets. The edge functions rely on this variable and currently use the
+`gpt-4o-mini` model. After updating the secret, redeploy the
+`generate-metadata` and `generate-use-case` functions so they pick up the new
+value.
+
 ## Database Schema
 
 ### `prompts` Table


### PR DESCRIPTION
## Summary
- add troubleshooting section under setup instructions explaining that admins and prompters must set `OPENAI_API_KEY`
- note that edge functions use `gpt-4o-mini` and must be redeployed when secrets change

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686a57c5972c8320a6da97a2be3a68ad