### PR TITLE
Improve AI model error message mapping

### DIFF
--- a/src/pages/admin/components/prompts/components/AutoGenerateButton.tsx
+++ b/src/pages/admin/components/prompts/components/AutoGenerateButton.tsx
@@ -109,6 +109,11 @@ export function AutoGenerateButton({ promptText, onMetadataGenerated, disabled }
         errorMessage = "You don't have permission to use auto-generate features.";
       } else if (error.message?.includes("OpenAI API key") || error.message?.includes("not configured")) {
         errorMessage = "AI service is not properly configured. Please contact the administrator.";
+      } else if (
+        error.message?.toLowerCase().includes("model") ||
+        error.message?.toLowerCase().includes("does not exist")
+      ) {
+        errorMessage = "AI model not available. Please update the edge function.";
       } else if (error.message?.includes("OpenAI")) {
         errorMessage = "AI service temporarily unavailable. Please try again later.";
       }


### PR DESCRIPTION
## Summary
- detect error messages that mention missing AI models in `AutoGenerateButton`
- surface a specific toast guiding users to update the edge function

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686a57cfefc88320ae6715f1791f6602